### PR TITLE
Allow for $ constants greater than $9

### DIFF
--- a/grammars/awk.cson
+++ b/grammars/awk.cson
@@ -146,7 +146,7 @@
         'name': 'variable.language.awk'
       }
       {
-        'match': '\\$[0-9]'
+        'match': '\\$[0-9]+'
         'name': 'constant.language.awk'
       }
     ]


### PR DESCRIPTION
Hi, thanks very much for creating this plugin; it is proving to be quite nice for a school programming project of mine.

However, I've noticed that while variables `$0` through `$9` are colored properly, `$10` and onward are only partially colored. Considering that the fix is quite literally a one-character tweak to the grammar file, I've taken the liberty of making the fix and submitting this pull request. All you need to do is merge it in should you find it acceptable.

**Before the fix is applied (note `$10`, `$11`, and `$12`):**
<img width="194" alt="screen shot 2016-04-12 at 9 18 02 pm" src="https://cloud.githubusercontent.com/assets/872474/14482776/16aa62a4-00f5-11e6-9212-8bbacb69396c.png">

Thanks very much,
Caleb 
