### PR TITLE
Remove deprecated Shadow DOM selector

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,4 +1,4 @@
-atom-text-editor::shadow {
+atom-text-editor {
     .meta.debug {
       background-color: fade(@background-color-warning, 20%) !important;
       border: 1px solid fade(@background-color-warning, 50%);


### PR DESCRIPTION
Shadow DOM selectors have been dropped as of Atom 1.13. Packages and themes still using them are triggering deprecation warnings; this PR fixes that for this package so no deprecations are shown.

@c-steiner You should cut a patch release after this has been merged.