### PR TITLE
Issue 11: fixed the `end` regex of the *action* pattern

### DIFF
--- a/grammars/awk.cson
+++ b/grammars/awk.cson
@@ -84,7 +84,7 @@
           'name': 'entity.name.action.begin.awk'
         '3':
           'name': 'entity.name.action.begin.awk'
-      'end': '^\}'
+      'end': '\}'
       'endCaptures':
         '0':
           'name': 'entity.name.action.end.awk'


### PR DESCRIPTION
Fixed the *action* pattern that caused recursive matching when closing bracket was not on the beginning of a line.